### PR TITLE
fix: Add `.svelte-kit` to ignored paths

### DIFF
--- a/src/globs.ts
+++ b/src/globs.ts
@@ -70,6 +70,7 @@ export const GLOB_EXCLUDE = [
   '**/.vitepress/cache',
   '**/.nuxt',
   '**/.next',
+  '**/.svelte-kit',
   '**/.vercel',
   '**/.changeset',
   '**/.idea',


### PR DESCRIPTION
With the out-of-the box config and svelte plugin enabled, files in the `.svelte-kit` directory are linted. This simple PR adds `'**/.svelte-kit'` to `GLOB_EXCLUDE`.